### PR TITLE
Fix compatibility with LiveLockScreen extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -831,6 +831,9 @@ _positionOverflow() {
         this._promptActive = true;
 
         for (const widget of this._dialog._backgroundGroup) {
+            const blurEffect = widget.get_effect('blur');
+            if (!blurEffect) continue;
+
             widget.ease_property('@effects.blur.radius', PROMPT_BLUR_RADIUS, {
                 duration: PROMPT_BLUR_DURATION,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
@@ -852,6 +855,9 @@ _positionOverflow() {
             this._enforceCardLimit(this._notifBox);
 
         for (const widget of this._dialog._backgroundGroup) {
+            const blurEffect = widget.get_effect('blur');
+            if (!blurEffect) continue;
+
             widget.ease_property('@effects.blur.radius', 0, {
                 duration: PROMPT_BLUR_DURATION,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,


### PR DESCRIPTION
Hi! First off, great extension! Really love how it looks.

I tried combining it with my own extension and it generally works fine, but I noticed a small bug in `_onPromptShow` and `_onPromptHide`. When animating the blur effect:

```js
widget.ease_property('@effects.blur.radius', PROMPT_BLUR_RADIUS, {
    duration: PROMPT_BLUR_DURATION,
    mode: Clutter.AnimationMode.EASE_OUT_QUAD,
});
```

The code assumes a blur effect is always present on the widget. This isn't the case for extensions that manage background effects differently, which causes the function to fail silently or error out.

The fix is a simple existence check before animating:

```js
const blurEffect = widget.get_effect('blur');
if (!blurEffect) continue;
```

This lets other extensions manage background effects as they see fit, while keeping your intended behavior fully intact when the blur effect is present.