### PR TITLE
implement background actor state management and blur effect adjustments

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -61,6 +61,8 @@ const PowerProfilesIface = `<node>
 </node>`;
 
 const PowerProfilesProxy = Gio.DBusProxy.makeProxyWrapper(PowerProfilesIface);
+const BACKGROUND_ACTOR_Y_OFFSET = 0.5;
+const BACKGROUND_ACTOR_Z_POSITION = 1;
 
 export default class WackLockscreenClockExtension extends Extension {
     // ── Single Source of Truth for Prompt State ───────────────────────────
@@ -125,6 +127,7 @@ export default class WackLockscreenClockExtension extends Extension {
         this._originalCupertinoText = null;
         this._originalCupertinoCount = 0;
         this._animationState = createAnimationState();
+        this._backgroundActorStates = new Map();
 
         // Track state transitions to prevent redundant side-effects
         this._wasPromptActive = false;
@@ -140,10 +143,7 @@ export default class WackLockscreenClockExtension extends Extension {
         // Prevents the shell from stomping our custom blur transitions.
         this._origUpdateBgEffects = dialog._updateBackgroundEffects.bind(dialog);
         dialog._updateBackgroundEffects = () => {
-            for (const widget of dialog._backgroundGroup) {
-                const effect = widget.get_effect('blur');
-                if (effect) effect.set({ brightness: 1.0, radius: 0 });
-            }
+            this._applyBackgroundBlur(dialog._adjustment?.value ?? 0);
         };
         dialog._updateBackgroundEffects();
 
@@ -495,15 +495,8 @@ export default class WackLockscreenClockExtension extends Extension {
             }
             this._wasPromptActive = isNowActive;
 
-            const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
             const isCupertino = this._lockscreenMode === 'cupertino';
-            const globalBlur = isCupertino ? 0 : PROMPT_BLUR_RADIUS * scaleFactor * progress;
-            const globalBrightness = isCupertino ? 1.0 : 1.0 - (1.0 - PROMPT_BLUR_BRIGHTNESS) * progress;
-
-            for (const widget of dialog._backgroundGroup) {
-                const effect = widget.get_effect('blur');
-                if (effect) effect.set({ radius: globalBlur, brightness: globalBrightness });
-            }
+            this._applyBackgroundBlur(progress);
 
             const hasNotifs = this._notifManager.hasVisibleNotifs();
             const cardBlur = hasNotifs ? NOTIF_BLUR_RADIUS * (1 - progress) : 0;
@@ -597,6 +590,93 @@ export default class WackLockscreenClockExtension extends Extension {
         }
     }
 
+    _syncBackgroundActors() {
+        const backgroundGroup = this._dialog?._backgroundGroup;
+        if (!backgroundGroup)
+            return;
+
+        this._backgroundActorStates ??= new Map();
+        const activeActors = new Set(backgroundGroup.get_children());
+
+        // GNOME recreates these actors when the monitor layout changes. Drop
+        // stale entries so destroyed actors are not retained until disable().
+        for (const actor of this._backgroundActorStates.keys()) {
+            if (!activeActors.has(actor))
+                this._backgroundActorStates.delete(actor);
+        }
+
+        for (const actor of activeActors) {
+            let state = this._backgroundActorStates.get(actor);
+
+            if (!state) {
+                state = {
+                    y: actor.y,
+                    zPosition: actor.z_position,
+                };
+                this._backgroundActorStates.set(actor, state);
+            } else {
+                // Preserve legitimate geometry changes made by GNOME or another
+                // extension without treating our own half-pixel offset as new.
+                const patchedY = state.y + BACKGROUND_ACTOR_Y_OFFSET;
+                if (Math.abs(actor.y - patchedY) > 0.01)
+                    state.y = actor.y;
+                if (actor.z_position !== BACKGROUND_ACTOR_Z_POSITION)
+                    state.zPosition = actor.z_position;
+            }
+
+            // Shell.BlurEffect can render the primary lock-screen actor black in
+            // multi-monitor layouts when all backgrounds share the default Z.
+            // A non-zero Z avoids that path; the half-pixel offset prevents the
+            // one-pixel seam otherwise introduced by the workaround.
+            actor.set({
+                y: state.y + BACKGROUND_ACTOR_Y_OFFSET,
+                z_position: BACKGROUND_ACTOR_Z_POSITION,
+            });
+        }
+    }
+
+    _restoreBackgroundActors() {
+        if (!this._backgroundActorStates)
+            return;
+
+        for (const [actor, state] of this._backgroundActorStates) {
+            try {
+                if (actor.get_parent()) {
+                    actor.set({
+                        y: state.y,
+                        z_position: state.zPosition,
+                    });
+                }
+            } catch (e) {
+                // Actors destroyed during a monitor reconfiguration need no
+                // restoration; their replacements are tracked separately.
+            }
+        }
+
+        this._backgroundActorStates.clear();
+        this._backgroundActorStates = null;
+    }
+
+    _applyBackgroundBlur(progress) {
+        this._syncBackgroundActors();
+
+        const clampedProgress = Math.max(0, Math.min(1, progress));
+        const isCupertino = this._lockscreenMode === 'cupertino';
+        const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        const radius = isCupertino
+            ? 0
+            : PROMPT_BLUR_RADIUS * scaleFactor * clampedProgress;
+        const brightness = isCupertino
+            ? 1.0
+            : 1.0 - (1.0 - PROMPT_BLUR_BRIGHTNESS) * clampedProgress;
+
+        for (const actor of this._dialog?._backgroundGroup ?? []) {
+            const effect = actor.get_effect('blur');
+            if (effect)
+                effect.set({ radius, brightness });
+        }
+    }
+
     _updateClockAlpha() {
         const dialog = this._dialog;
         if (!dialog || !dialog._clock || typeof dialog._clock.setWallpaperAlpha !== 'function')
@@ -677,14 +757,7 @@ export default class WackLockscreenClockExtension extends Extension {
 
             const progress = this._dialog?._adjustment?.value ?? 0;
             const isCupertino = this._lockscreenMode === 'cupertino';
-            const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-            const targetRadius = isCupertino ? 0 : PROMPT_BLUR_RADIUS * scaleFactor * progress;
-            const targetBrightness = isCupertino ? 1.0 : 1.0 - (1.0 - PROMPT_BLUR_BRIGHTNESS) * progress;
-
-            for (const widget of this._dialog?._backgroundGroup ?? []) {
-                const effect = widget.get_effect('blur');
-                if (effect) effect.set({ radius: targetRadius, brightness: targetBrightness });
-            }
+            this._applyBackgroundBlur(progress);
 
             if (this._notifManager._notifBox) {
                 this._notifManager._notifBox.opacity = isCupertino ? Math.round(255 * (1 - progress)) : 255;
@@ -1466,9 +1539,12 @@ export default class WackLockscreenClockExtension extends Extension {
         }
 
         if (this._dialog && this._origUpdateBgEffects) {
+            this._restoreBackgroundActors();
             this._dialog._updateBackgroundEffects = this._origUpdateBgEffects;
             this._origUpdateBgEffects = null;
             this._dialog._updateBackgroundEffects();
+        } else {
+            this._restoreBackgroundActors();
         }
 
         if (this._dialog && this._origUpdateUserSwitchVisibility) {

--- a/extension.js
+++ b/extension.js
@@ -851,12 +851,13 @@ export default class WackLockscreenClockExtension extends Extension {
 
     // ── Side Effects Only: State is derived via getter ────────────────────
     _onPromptShow() {
+        this._setupAuthPromptOverride();
+
         const isCupertino = this._lockscreenMode === 'cupertino';
         if (isCupertino) {
             this._promptActor?.remove_style_class_name('wack-cupertino-rest');
             this._promptActor?.add_style_class_name('wack-cupertino-prompt');
             this._cupertinoToPrompt = true;
-            this._setupCupertinoAvatarOverride();
         }
     }
 
@@ -996,50 +997,71 @@ export default class WackLockscreenClockExtension extends Extension {
         this._updateCupertinoHintCycle();
     }
 
-    _setupCupertinoAvatarOverride() {
-        if (this._cupertinoAvatarSetup) return;
+    _setupAuthPromptOverride() {
+        if (this._authPromptOverrideSetup) return;
         const authPrompt = this._dialog?._authPrompt ?? this._dialog?._promptBox?._authPrompt;
         if (!authPrompt) return;
-        this._cupertinoAvatarSetup = true;
+        this._authPromptOverrideSetup = true;
 
-        if (!this._cupertinoOrigUpdateUser) {
+        if (!this._authPromptOrigUpdateUser) {
             const methodName = authPrompt.setUser ? 'setUser' : 'updateUser';
-            this._cupertinoOrigMethodName = methodName;
-            this._cupertinoOrigUpdateUser = authPrompt[methodName].bind(authPrompt);
+            this._authPromptOrigMethodName = methodName;
+            this._authPromptOrigUpdateUser = authPrompt[methodName];
             authPrompt[methodName] = (user) => {
-                this._cupertinoOrigUpdateUser(user);
+                const currentUser = authPrompt._userWell?.get_child()?._user;
+                // GNOME clears the visual user before the prompt fade starts.
+                // Keep the populated widget alive until the prompt is destroyed.
+                if (this._authPromptCancelling && user === null && currentUser)
+                    return;
+
+                this._authPromptOrigUpdateUser.call(authPrompt, user);
                 const uw = authPrompt._userWell?.get_child();
-                if (uw && uw._avatar) {
+                if (this._lockscreenMode === 'cupertino' && uw?._avatar) {
                     uw._avatar.visible = true;
                     uw._avatar.opacity = 0;
                 }
             };
+
+            this._authPromptOrigCancel = authPrompt.cancel;
+            authPrompt.cancel = (...args) => {
+                this._authPromptCancelling = true;
+                try {
+                    return this._authPromptOrigCancel.apply(authPrompt, args);
+                } finally {
+                    this._authPromptCancelling = false;
+                }
+            };
+
             const promptUserWidget = authPrompt._userWell?.get_child();
-            if (promptUserWidget?._avatar) {
+            if (this._lockscreenMode === 'cupertino' && promptUserWidget?._avatar) {
                 promptUserWidget._avatar.visible = true;
                 promptUserWidget._avatar.opacity = 0;
             }
         }
 
-        authPrompt.connectObject('destroy', () => this._teardownCupertinoAvatarOverride(), this);
+        authPrompt.connectObject('destroy', () => this._teardownAuthPromptOverride(), this);
     }
 
-    _teardownCupertinoAvatarOverride() {
+    _teardownAuthPromptOverride() {
         const authPrompt = this._dialog?._authPrompt ?? this._dialog?._promptBox?._authPrompt;
         if (authPrompt) authPrompt.disconnectObject(this);
 
-        if (authPrompt && this._cupertinoOrigUpdateUser && this._cupertinoOrigMethodName) {
-            authPrompt[this._cupertinoOrigMethodName] = this._cupertinoOrigUpdateUser;
-        }
-        this._cupertinoOrigUpdateUser = null;
-        this._cupertinoOrigMethodName = null;
+        if (authPrompt && this._authPromptOrigUpdateUser && this._authPromptOrigMethodName)
+            authPrompt[this._authPromptOrigMethodName] = this._authPromptOrigUpdateUser;
+        if (authPrompt && this._authPromptOrigCancel)
+            authPrompt.cancel = this._authPromptOrigCancel;
+
+        this._authPromptOrigUpdateUser = null;
+        this._authPromptOrigMethodName = null;
+        this._authPromptOrigCancel = null;
+        this._authPromptCancelling = false;
 
         const promptUserWidget = authPrompt?._userWell?.get_child();
         if (promptUserWidget?._avatar) {
             promptUserWidget._avatar.visible = true;
             promptUserWidget._avatar.opacity = 255;
         }
-        this._cupertinoAvatarSetup = false;
+        this._authPromptOverrideSetup = false;
     }
 
     _applyPromptModeLayout() {
@@ -1568,7 +1590,7 @@ export default class WackLockscreenClockExtension extends Extension {
             this._inhibitHintTimeoutId = null;
         }
 
-        this._teardownCupertinoAvatarOverride();
+        this._teardownAuthPromptOverride();
         if (this._cupertinoHintCycleId) {
             GLib.source_remove(this._cupertinoHintCycleId);
             this._cupertinoHintCycleId = null;

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "gettext-domain": "wack-lockscreen-clock@rinzler69-wastaken.github.com",
   "settings-schema": "org.gnome.shell.extensions.wack-lockscreen-clock",
   "url": "https://github.com/rinzler69-wastaken/wack-sonoma-lockscreen",
-  "version-name": "1.5.0",
+  "version-name": "1.5.1",
   "donations": {
     "paypal": "ArtFazil",
     "kofi": "mikerinzler69",


### PR DESCRIPTION
Hey! I'm using your extension and looks great! However, I noticed a little bug when using it with 2 screens so I fixed it here, you can review it if you like and merge it if you're agree with it. Here's a detailed description of what I've done:

## Problem

In a multi-monitor setup, entering the password prompt in Legacy mode caused the primary monitor to turn black while the secondary monitor continued showing the blurred wallpaper.

The extension was already updating the blur effect for every monitor, so this was not a monitor-selection issue. It appears to be GNOME Shell’s multi-monitor `Shell.BlurEffect` rendering behavior.

## Solution

This change applies the established background-actor workaround:

- Give each lock-screen background actor a nonzero Z position.
- Add a 0.5px Y offset to prevent the seam caused by that Z-position change.
- Track original actor geometry so the workaround is idempotent and reversible.
- Reapply it when GNOME recreates backgrounds after monitor or scale changes.
- Centralize blur updates and preserve the current prompt-transition progress.
- Restore the original actor geometry when the extension is disabled.

The change reuses GNOME’s existing background managers and blur effects, which should minimize conflicts with other extensions.

Cupertino mode remains unblurred.

## Verification

- [x] JavaScript syntax checks
- [x] GSettings schema validation
- [x] `git diff --check`
- [ ] Live test with two monitors
- [ ] Monitor hot-plug test
- [ ] Mixed-scale monitor test

## Compatibility

Intended for the extension’s existing GNOME Shell 46–50 support range.

## Notes

This approach is based on the multi-monitor actor-order workaround used by Blur My Shell, adapted without replacing GNOME’s background actors or effects.