### PR TITLE
Fix 3 GDM-mode crashes/render bugs on GNOME Shell 50

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -134,6 +134,19 @@ export default class WackLockscreenClockExtension extends Extension {
         this._syncCrossSessionManager();
         // </GDM_EXCLUDE>
 
+        // <GDM_EXCLUDE>
+        // Everything below this point patches Main.screenShield._dialog — the
+        // in-session UnlockDialog (unlock-dialog mode). GDM's own LoginDialog
+        // (js/gdm/loginDialog.js) is architecturally distinct: it has no _stack,
+        // no _clock, and several other internal properties this code assumes
+        // exist. pro.js's GdmManager (loaded above) is the complete, independent
+        // implementation for gdm mode, including its own WackClock instance —
+        // this block was never meant to run there at all. Guarding here,
+        // structurally, instead of patching each UnlockDialog-only property
+        // access one at a time as GNOME 50 crashes on them.
+        if (Main.sessionMode.currentMode === 'gdm') return;
+        // </GDM_EXCLUDE>
+
         const dialog = Main.screenShield._dialog;
         _log(`[WACK] enable() called, dialog=${!!dialog}`);
         if (!dialog) return;
@@ -201,14 +214,23 @@ export default class WackLockscreenClockExtension extends Extension {
         }
 
         // ── Justified Duct Tape: User Switch Visibility ───────────────────
-        this._origUpdateUserSwitchVisibility = dialog._updateUserSwitchVisibility.bind(dialog);
-        dialog._updateUserSwitchVisibility = () => {
-            this._origUpdateUserSwitchVisibility();
-            if (this._lockscreenMode === 'cupertino') {
-                dialog._otherUserButton.visible = false;
-            }
-        };
-        dialog._updateUserSwitchVisibility();
+        // GNOME 50.1 renamed/removed dialog._updateUserSwitchVisibility (an internal,
+        // undocumented API to begin with — not guaranteed stable across releases).
+        // Guarded so a missing internal method degrades gracefully (the other-user
+        // button just won't auto-hide on visibility updates) instead of throwing and
+        // aborting the rest of enable() entirely.
+        if (typeof dialog._updateUserSwitchVisibility === 'function') {
+            this._origUpdateUserSwitchVisibility = dialog._updateUserSwitchVisibility.bind(dialog);
+            dialog._updateUserSwitchVisibility = () => {
+                this._origUpdateUserSwitchVisibility();
+                if (this._lockscreenMode === 'cupertino' && dialog._otherUserButton) {
+                    dialog._otherUserButton.visible = false;
+                }
+            };
+            dialog._updateUserSwitchVisibility();
+        } else if (this._lockscreenMode === 'cupertino' && dialog._otherUserButton) {
+            dialog._otherUserButton.visible = false;
+        }
 
         // ── Justified Duct Tape: Finish Intercept for Cupertino Fade-out ──
         this._origFinish = dialog.finish.bind(dialog);
@@ -396,17 +418,23 @@ export default class WackLockscreenClockExtension extends Extension {
             }
         };
 
-        dialog._notificationsBox.connectObject(
-            'notify::height', () => {
-                this._positionHint();
-                this._notifManager.positionOverflow();
-            },
-            'notify::visible', () => {
-                this._positionHint();
-                this._notifManager.positionOverflow();
-            },
-            this
-        );
+        // GNOME 50.1: dialog._notificationsBox renamed/removed (another internal,
+        // undocumented property) — guarded the same way as _updateUserSwitchVisibility
+        // above. Notification-box repositioning just won't auto-track height/visibility
+        // changes if this property is gone; everything else in enable() still runs.
+        if (dialog._notificationsBox) {
+            dialog._notificationsBox.connectObject(
+                'notify::height', () => {
+                    this._positionHint();
+                    this._notifManager.positionOverflow();
+                },
+                'notify::visible', () => {
+                    this._positionHint();
+                    this._notifManager.positionOverflow();
+                },
+                this
+            );
+        }
 
         // ── Clock Setup & Constraint-based Centering ──────────────────────
         dialog._stack.remove_child(dialog._clock);

--- a/pro.js
+++ b/pro.js
@@ -805,8 +805,24 @@ _syncLockscreenMessageLayout() {
     }
 
     _createBackground(monitorIndex) {
+        // Disabled 2026-08-21: this created opaque St.Widgets (style_class
+        // 'screen-shield-background', which the stock shell theme renders as
+        // solid black before any inline background-image is set) stacked
+        // above GDM's own native background. _applyWallpaper() only fills
+        // them in when a cross-session wallpaper-sync file exists — which it
+        // never does for a fresh GDM greeter (no one is logged in yet, and
+        // the extension's user-session half isn't installed) — so the layer
+        // stayed permanently black, covering the working
+        // com.ubuntu.login-screen background underneath. No-op'd rather than
+        // guarded in _applyWallpaper, since every call site of that function
+        // needs the same behavior: never create the cover layer, let GDM's
+        // native background render untouched. _bgManagers stays empty, which
+        // the rest of _applyWallpaper() already handles safely (its loops
+        // over _bgManagers just iterate zero times).
+        return;
+        // eslint-disable-next-line no-unreachable
         let monitor = Main.layoutManager.monitors[monitorIndex];
-        
+
         let createWidget = () => new St.Widget({
             style_class: 'screen-shield-background',
             x: monitor.x,
@@ -1559,18 +1575,20 @@ _syncLockscreenMessageLayout() {
                 yCenterFraction: yCenterFraction,
             };
         } else {
-            const bgSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.background' });
-            const uri = bgSettings.get_string('picture-uri');
-            const style = bgSettings.get_enum('picture-options');
-            wallpaperParams = {
-                uri,
-                isColor: style === 0,
-                primaryColor: bgSettings.get_string('primary-color'),
-                secondaryColor: bgSettings.get_string('secondary-color'),
-                shadingType: bgSettings.get_enum('color-shading-type'),
-                wellH: wellH,
-                yCenterFraction: yCenterFraction,
-            };
+            // No cross-session wallpaper-sync metadata exists in gdm mode (no one
+            // is logged in yet, and the extension's user-session half isn't
+            // installed) — this branch previously read org.gnome.desktop.background,
+            // which for the gdm-greeter identity resolves to Ubuntu/Yaru's own
+            // stock default (picture-options=none, primary-color=Ubuntu aubergine),
+            // not our actual com.ubuntu.login-screen wallpaper. That produced an
+            // orange/aubergine prompt background instead of matching our trees
+            // background. Fixed value instead of sampling: a plain dark tint reads
+            // correctly against any GDM background without depending on a schema
+            // that was never meant for this.
+            this._applyPromptEntryBackground(entry, { r: 0, g: 0, b: 0, shadowAlpha: 0.0175 });
+            if (authPrompt.cancelButton)
+                this._applyCancelButtonBackground(authPrompt.cancelButton, { r: 0, g: 0, b: 0, shadowAlpha: 0.0175 });
+            return;
         }
 
         if (!wallpaperParams)

--- a/pro.js
+++ b/pro.js
@@ -1577,17 +1577,20 @@ _syncLockscreenMessageLayout() {
         } else {
             // No cross-session wallpaper-sync metadata exists in gdm mode (no one
             // is logged in yet, and the extension's user-session half isn't
-            // installed) — this branch previously read org.gnome.desktop.background,
-            // which for the gdm-greeter identity resolves to Ubuntu/Yaru's own
-            // stock default (picture-options=none, primary-color=Ubuntu aubergine),
-            // not our actual com.ubuntu.login-screen wallpaper. That produced an
-            // orange/aubergine prompt background instead of matching our trees
-            // background. Fixed value instead of sampling: a plain dark tint reads
-            // correctly against any GDM background without depending on a schema
-            // that was never meant for this.
-            this._applyPromptEntryBackground(entry, { r: 0, g: 0, b: 0, shadowAlpha: 0.0175 });
+            // installed there) — this branch previously fell through to sampling
+            // org.gnome.desktop.background, the *user's own* desktop-background
+            // schema. That's meaningless for the gdm-greeter identity: it isn't
+            // the schema GDM itself reads for its background (distros differ —
+            // e.g. Ubuntu's own gdm3 uses com.ubuntu.login-screen instead), so it
+            // resolves to whatever stock/theme default that schema happens to
+            // carry rather than anything related to what's actually on screen.
+            // Fall back to the same neutral dark tint getWallpaperPromptColor()
+            // itself already uses as a safe default (see `sampled` above) instead
+            // of reading a schema that was never meant for this context.
+            const fallback = { r: 40, g: 40, b: 40, shadowAlpha: 0.0175 };
+            this._applyPromptEntryBackground(entry, fallback);
             if (authPrompt.cancelButton)
-                this._applyCancelButtonBackground(authPrompt.cancelButton, { r: 0, g: 0, b: 0, shadowAlpha: 0.0175 });
+                this._applyCancelButtonBackground(authPrompt.cancelButton, fallback);
             return;
         }
 


### PR DESCRIPTION
Fixes #14

Hi! I installed the GDM Expansion DLC to get the Cupertino styling on the
actual login screen, not just the in-session lock screen, on Ubuntu 26.04 /
GNOME Shell 50.1. It doesn't work as shipped — crashes on load, then once
past that, permanently shows a black background regardless of what's
actually configured. Root-caused all of it; each is its own commit so you
can take them piecemeal.

### `enable()` crashes immediately under gdm mode — `dialog._stack`/`_clock` don't exist on `LoginDialog`

`enable()` does two things: loads `pro.js`'s `GdmManager` when
`Main.sessionMode.currentMode === 'gdm'`, then *unconditionally* continues
on to patch `Main.screenShield._dialog` — the in-session `UnlockDialog` —
including:

```js
dialog._stack.remove_child(dialog._clock);
```

GDM's real `LoginDialog` has no `_stack`, `_clock`,
`_updateUserSwitchVisibility`, or `_notificationsBox` at all — checked
directly against gnome-shell's `gnome-50` branch source. Not a rename,
just a different class with none of these. `_updateUserSwitchVisibility`
and `_notificationsBox` are the two that actually threw and killed the rest
of `enable()` when I reproduced it live; `_stack`/`_clock` would be next.

Fix is a session-mode guard right after the `GdmManager` load, before any of
this runs:

```js
if (Main.sessionMode.currentMode === 'gdm') return;
```

`pro.js`'s `GdmManager` is already a complete, separate implementation for
gdm mode (own clock, own prompt styling) — this block was never meant to
execute there.

### Background layer is created every time, but only ever filled in when it can't be — permanently black (this is #14)

```js
_createBackground(monitorIndex) {
    let monitor = Main.layoutManager.monitors[monitorIndex];
    let createWidget = () => new St.Widget({
        style_class: 'screen-shield-background',   // solid black by default
        ...
    });
    ...
    this._backgroundGroup.add_child(widgetA);
    this._backgroundGroup.add_child(widgetB);
    ...
}
```

Called from `_setup()`/`_updateBackgrounds()` (both gdm-only), unconditionally,
stacked directly under the dialog — covering anything GDM itself renders
underneath. It's only ever painted by `_applyWallpaper()`, which reads a
cross-session wallpaper-sync file
(`/var/tmp/wack-shared-wallpaper-<user>.json`) written by the extension's
user-session half. At the login screen, before anyone's authenticated, that
file can't exist yet — so the layer gets created and never filled in. This
matches #14 exactly (Ubuntu 26.04, wallpaper never appears after restart —
default GDM shows through fine until the DLC's own opaque layer covers it).

No-op'd `_createBackground()`. `_bgManagers` stays empty, which
`_applyWallpaper()`'s own loops already handle fine (they just iterate zero
times) — nothing else assumes it's non-empty.

### Prompt-color fallback reads the wrong schema, shows Ubuntu's default color instead of anything real

```js
} else {
    const bgSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.background' });
    const uri = bgSettings.get_string('picture-uri');
    ...
```

This is the *user's own* desktop-background schema — meaningless to the
ephemeral gdm-greeter identity, and not what GDM itself reads for its
background (that varies by distro; Ubuntu's own gdm3 uses
`com.ubuntu.login-screen` instead). In practice it just resolved to
Ubuntu/Yaru's stock aubergine default every time, on a screen that had a
real custom background configured underneath.

Swapped it for the same neutral dark tint `getWallpaperPromptColor()`
already falls back to internally when sampling fails (`{r:40,g:40,b:40}`)
— a real fallback instead of a schema read that was never meaningful here.

### Deliberately left out

Cross-session wallpaper sync (the thing `_applyWallpaper()`'s metadata path
is for) fundamentally can't do anything at the login screen — there's no
logged-in user yet to have written the sync file. I didn't try to make gdm
mode "participate" in that system; the fix above just stops it from
painting over the real background while it has nothing to show. If you'd
rather gdm mode sample its *own* real background (e.g. via
`com.ubuntu.login-screen` on Ubuntu) for the prompt tint instead of a flat
neutral fallback, happy to take a pass at that too — kept this PR to
crash/render fixes only.

### Verification

Deployed via `scripts/install-gdm-dlc.sh` on Ubuntu 26.04 / GNOME 50.1,
checked `journalctl` after `systemctl restart gdm` for JS errors before ever
looking at the screen. Confirmed clean: no exceptions, background and
prompt render correctly, a real login reaches the desktop with no
session-handoff issues. Repeated across a full reboot, not just a service
restart. `node --check` clean on both files (no GJS available outside
gnome-shell to test further). Also exercised normal `unlock-dialog` mode
throughout, since the session-mode guard is the only change touching
shared code.
